### PR TITLE
Add REST methods to HTTPProxy (#1)

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,8 @@ gemspec
 gem 'colorize'
 gem 'pry-byebug'
 gem 'activesupport'
+
+group :test do
+  gem 'rest-client', '~> 2.0'
+  gem 'rspec', '~> 3.6'
+end

--- a/spec/evil-proxy/httpproxy_spec.rb
+++ b/spec/evil-proxy/httpproxy_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe EvilProxy::HTTPProxyServer do
+  before :all do
+    @server = EvilProxy::MITMProxyServer.new Port: 3128, Quiet: true
+    @server.start
+  end
+
+  after :all do
+    @server.shutdown
+  end
+
+  let(:proxy) { 'http://127.0.0.1:3128' }
+
+  it 'proxy GET requests' do
+    content = HTTPClient.get('http://httpbin.org/get', proxy)
+
+    expect(content).not_to be_nil
+  end
+
+  it 'proxy HEAD requests' do
+    content = HTTPClient.head('https://httpbin.org/get', proxy)
+
+    expect(content).not_to be_nil
+  end
+
+  it 'proxy POST requests' do
+    content = HTTPClient.post('https://httpbin.org/post', { param: 'value' }, proxy)
+
+    expect(content).not_to be_nil
+
+    json = JSON.parse(content)
+
+    expect(json['form']['param']).to eq('value')
+  end
+
+  it 'proxy PUT requests' do
+    content = HTTPClient.put('https://httpbin.org/put', { param: 'value' }, proxy)
+
+    expect(content).not_to be_nil
+
+    json = JSON.parse(content)
+
+    expect(json['form']['param']).to eq('value')
+  end
+
+  it 'proxy PATCH requests' do
+    content = HTTPClient.patch('https://httpbin.org/patch', { param: 'value' }, proxy)
+
+    expect(content).not_to be_nil
+
+    json = JSON.parse(content)
+
+    expect(json['form']['param']).to eq('value')
+  end
+
+  it 'proxy DELETE requests' do
+    content = HTTPClient.delete('https://httpbin.org/delete', proxy)
+
+    expect(content).not_to be_nil
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,11 @@
+require 'rest-client'
+require 'json'
+
+require 'evil-proxy'
+require 'evil-proxy/async'
+
+Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
+
+RSpec.configure do |config|
+  config.order = 'random'
+end

--- a/spec/support/http_client.rb
+++ b/spec/support/http_client.rb
@@ -1,0 +1,33 @@
+class HTTPClient
+  class << self
+    def get(url, proxy)
+      RestClient::Request.execute(method: :get, url: url, proxy: proxy,
+                                  verify_ssl: OpenSSL::SSL::VERIFY_NONE)
+    end
+
+    def head(url, proxy)
+      RestClient::Request.execute(method: :head, url: url, proxy: proxy,
+                                  verify_ssl: OpenSSL::SSL::VERIFY_NONE)
+    end
+
+    def post(url, payload, proxy)
+      RestClient::Request.execute(method: :post, url: url, payload: payload,
+                                  proxy: proxy, verify_ssl: OpenSSL::SSL::VERIFY_NONE)
+    end
+
+    def put(url, payload, proxy)
+      RestClient::Request.execute(method: :put, url: url, payload: payload,
+                                  proxy: proxy, verify_ssl: OpenSSL::SSL::VERIFY_NONE)
+    end
+
+    def patch(url, payload, proxy)
+      RestClient::Request.execute(method: :patch, url: url, payload: payload,
+                                  proxy: proxy, verify_ssl: OpenSSL::SSL::VERIFY_NONE)
+    end
+
+    def delete(url, proxy)
+      RestClient::Request.execute(method: :delete, url: url, proxy: proxy,
+                                  verify_ssl: OpenSSL::SSL::VERIFY_NONE)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support of DELETE / PUT / PATCH requests to `EvilProxy::HTTPProxyServer` as requested in #1. Moreover, it includes tests for this class that checks if all the HTTP methods works.