### PR TITLE
Add webrick to dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,10 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in evil-proxy.gemspec
 gemspec
 
+gem 'activesupport'
 gem 'colorize'
 gem 'pry-byebug'
-gem 'activesupport'
+gem 'webrick'
 
 group :test do
   gem 'rest-client', '~> 2.0'


### PR DESCRIPTION
I added webrick to the Gemfile.  The two proxy classes extend webrick's proxy class.

I was finding that `proxy.start` was hanging until I manually installed webrick.