### PR TITLE
Proxy OPTIONS requests

### DIFF
--- a/lib/evil-proxy/httpproxy.rb
+++ b/lib/evil-proxy/httpproxy.rb
@@ -86,8 +86,10 @@ class EvilProxy::HTTPProxyServer < WEBrick::HTTPProxyServer
     end
   end
 
-  def do_OPTIONS(_req, res)
-    res['allow'] = SUPPORTED_METHODS.join(',')
+  def do_OPTIONS(req, res)
+    perform_proxy_request(req, res) do |http, path, header|
+      http.options(path, header)
+    end
   end
 
   define_callback_methods :when_initialize


### PR DESCRIPTION
This can be necessary for CORS.

Rather than returning our own Allow: header, the RFC states we should
not modify the server's response:

RFC 2068, § 14.7:

A proxy MUST NOT modify the Allow header field even if it does not
understand all the methods specified, since the user agent MAY have
other means of communicating with the origin server.